### PR TITLE
Closes #76 Add missing explanation of evaluation lifecycle

### DIFF
--- a/__build8/FenwickTree.test.js
+++ b/__build8/FenwickTree.test.js
@@ -1,0 +1,22 @@
+import { FenwickTree } from '../FenwickTree'
+
+describe('Fenwick Tree Implementation', () => {
+  const fenwickArray = new Array(1000)
+  const array = [3, 2, 0, 6, 5, -1, 2]
+  const length = array.length
+
+  const fenwickTree = new FenwickTree(fenwickArray, array, length)
+
+  it('Fenwick Tree - Prefix sum of array', () => {
+    const prefixSum = fenwickTree.getPrefixSum(fenwickArray, 6)
+    expect(prefixSum).toBe(23)
+  })
+
+  array[2] += 6
+  fenwickTree.update(fenwickArray, length, 2, 6)
+
+  it('Fenwick Tree - Prefix sum of Updated array', () => {
+    const prefixSum = fenwickTree.getPrefixSum(fenwickArray, 6)
+    expect(prefixSum).toBe(23)
+  })
+})

--- a/__build8/has_loop.py
+++ b/__build8/has_loop.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class ContainsLoopError(Exception):
+    pass
+
+
+class Node:
+    def __init__(self, data: Any) -> None:
+        self.data: Any = data
+        self.next_node: Node | None = None
+
+    def __iter__(self):
+        node = self
+        visited = set()
+        while node:
+            if node in visited:
+                raise ContainsLoopError
+            visited.add(node)
+            yield node.data
+            node = node.next_node
+
+    @property
+    def has_loop(self) -> bool:
+        """
+        A loop is when the exact same Node appears more than once in a linked list.
+        >>> root_node = Node(1)
+        >>> root_node.next_node = Node(2)
+        >>> root_node.next_node.next_node = Node(3)
+        >>> root_node.next_node.next_node.next_node = Node(4)
+        >>> root_node.has_loop
+        False
+        >>> root_node.next_node.next_node.next_node = root_node.next_node
+        >>> root_node.has_loop
+        True
+        """
+        try:
+            list(self)
+            return False
+        except ContainsLoopError:
+            return True
+
+
+if __name__ == "__main__":
+    root_node = Node(1)
+    root_node.next_node = Node(2)
+    root_node.next_node.next_node = Node(3)
+    root_node.next_node.next_node.next_node = Node(4)
+    print(root_node.has_loop)  # False
+    root_node.next_node.next_node.next_node = root_node.next_node
+    print(root_node.has_loop)  # True
+
+    root_node = Node(5)
+    root_node.next_node = Node(6)
+    root_node.next_node.next_node = Node(5)
+    root_node.next_node.next_node.next_node = Node(6)
+    print(root_node.has_loop)  # False
+
+    root_node = Node(1)
+    print(root_node.has_loop)  # False

--- a/__build8/mergesort.py
+++ b/__build8/mergesort.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+
+def merge(left_half: list, right_half: list) -> list:
+    """Helper function for mergesort.
+
+    >>> left_half = [-2]
+    >>> right_half = [-1]
+    >>> merge(left_half, right_half)
+    [-2, -1]
+
+    >>> left_half = [1,2,3]
+    >>> right_half = [4,5,6]
+    >>> merge(left_half, right_half)
+    [1, 2, 3, 4, 5, 6]
+
+    >>> left_half = [-2]
+    >>> right_half = [-1]
+    >>> merge(left_half, right_half)
+    [-2, -1]
+
+    >>> left_half = [12, 15]
+    >>> right_half = [13, 14]
+    >>> merge(left_half, right_half)
+    [12, 13, 14, 15]
+
+    >>> left_half = []
+    >>> right_half = []
+    >>> merge(left_half, right_half)
+    []
+    """
+    sorted_array = [None] * (len(right_half) + len(left_half))
+
+    pointer1 = 0  # pointer to current index for left Half
+    pointer2 = 0  # pointer to current index for the right Half
+    index = 0  # pointer to current index for the sorted array Half
+
+    while pointer1 < len(left_half) and pointer2 < len(right_half):
+        if left_half[pointer1] < right_half[pointer2]:
+            sorted_array[index] = left_half[pointer1]
+            pointer1 += 1
+            index += 1
+        else:
+            sorted_array[index] = right_half[pointer2]
+            pointer2 += 1
+            index += 1
+    while pointer1 < len(left_half):
+        sorted_array[index] = left_half[pointer1]
+        pointer1 += 1
+        index += 1
+
+    while pointer2 < len(right_half):
+        sorted_array[index] = right_half[pointer2]
+        pointer2 += 1
+        index += 1
+
+    return sorted_array
+
+
+def merge_sort(array: list) -> list:
+    """Returns a list of sorted array elements using merge sort.
+
+    >>> from random import shuffle
+    >>> array = [-2, 3, -10, 11, 99, 100000, 100, -200]
+    >>> shuffle(array)
+    >>> merge_sort(array)
+    [-200, -10, -2, 3, 11, 99, 100, 100000]
+
+    >>> shuffle(array)
+    >>> merge_sort(array)
+    [-200, -10, -2, 3, 11, 99, 100, 100000]
+
+    >>> array = [-200]
+    >>> merge_sort(array)
+    [-200]
+
+    >>> array = [-2, 3, -10, 11, 99, 100000, 100, -200]
+    >>> shuffle(array)
+    >>> sorted(array) == merge_sort(array)
+    True
+
+    >>> array = [-2]
+    >>> merge_sort(array)
+    [-2]
+
+    >>> array = []
+    >>> merge_sort(array)
+    []
+
+    >>> array = [10000000, 1, -1111111111, 101111111112, 9000002]
+    >>> sorted(array) == merge_sort(array)
+    True
+    """
+    if len(array) <= 1:
+        return array
+    # the actual formula to calculate the middle element = left + (right - left) // 2
+    # this avoids integer overflow in case of large N
+    middle = 0 + (len(array) - 0) // 2
+
+    # Split the array into halves till the array length becomes equal to One
+    # merge the arrays of single length returned by mergeSort function and
+    # pass them into the merge arrays function which merges the array
+    left_half = array[:middle]
+    right_half = array[middle:]
+
+    return merge(merge_sort(left_half), merge_sort(right_half))
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/__build8/momentum.rs
+++ b/__build8/momentum.rs
@@ -1,0 +1,144 @@
+/// Momentum Optimization
+///
+/// Momentum is an extension of gradient descent that accelerates convergence by accumulating
+/// a velocity vector in directions of persistent reduction in the objective function.
+/// This helps the optimizer navigate ravines and avoid getting stuck in local minima.
+///
+/// The algorithm maintains a velocity vector that accumulates exponentially decaying moving
+/// averages of past gradients. This allows the optimizer to build up speed in consistent
+/// directions while dampening oscillations.
+///
+/// The update equations are:
+/// velocity_{k+1} = beta * velocity_k + gradient_of_function(x_k)
+/// x_{k+1} = x_k - learning_rate * velocity_{k+1}
+///
+/// where beta (typically 0.9) controls how much past gradients influence the current update.
+///
+/// # Arguments
+///
+/// * `derivative_fn` - The function that calculates the gradient of the objective function at a given point.
+/// * `x` - The initial parameter vector to be optimized.
+/// * `learning_rate` - Step size for each iteration.
+/// * `beta` - Momentum coefficient (typically 0.9). Higher values give more weight to past gradients.
+/// * `num_iterations` - The number of iterations to run the optimization.
+///
+/// # Returns
+///
+/// A reference to the optimized parameter vector `x`.
+#[allow(dead_code)]
+pub fn momentum(
+    derivative: impl Fn(&[f64]) -> Vec<f64>,
+    x: &mut Vec<f64>,
+    learning_rate: f64,
+    beta: f64,
+    num_iterations: i32,
+) -> &mut Vec<f64> {
+    // Initialize velocity vector to zero
+    let mut velocity: Vec<f64> = vec![0.0; x.len()];
+
+    for _ in 0..num_iterations {
+        let gradient = derivative(x);
+
+        // Update velocity and parameters
+        for ((x_k, vel), grad) in x.iter_mut().zip(velocity.iter_mut()).zip(gradient.iter()) {
+            *vel = beta * *vel + grad;
+            *x_k -= learning_rate * *vel;
+        }
+    }
+    x
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_momentum_optimized() {
+        fn derivative_of_square(params: &[f64]) -> Vec<f64> {
+            params.iter().map(|x| 2.0 * x).collect()
+        }
+
+        let mut x: Vec<f64> = vec![5.0, 6.0];
+        let learning_rate: f64 = 0.01;
+        let beta: f64 = 0.9;
+        let num_iterations: i32 = 1000;
+
+        let minimized_vector = momentum(
+            derivative_of_square,
+            &mut x,
+            learning_rate,
+            beta,
+            num_iterations,
+        );
+
+        let test_vector = [0.0, 0.0];
+        let tolerance = 1e-6;
+
+        for (minimized_value, test_value) in minimized_vector.iter().zip(test_vector.iter()) {
+            assert!((minimized_value - test_value).abs() < tolerance);
+        }
+    }
+
+    #[test]
+    fn test_momentum_unoptimized() {
+        fn derivative_of_square(params: &[f64]) -> Vec<f64> {
+            params.iter().map(|x| 2.0 * x).collect()
+        }
+
+        let mut x: Vec<f64> = vec![5.0, 6.0];
+        let learning_rate: f64 = 0.01;
+        let beta: f64 = 0.9;
+        let num_iterations: i32 = 10;
+
+        let minimized_vector = momentum(
+            derivative_of_square,
+            &mut x,
+            learning_rate,
+            beta,
+            num_iterations,
+        );
+
+        let test_vector = [0.0, 0.0];
+        let tolerance = 1e-6;
+
+        for (minimized_value, test_value) in minimized_vector.iter().zip(test_vector.iter()) {
+            assert!((minimized_value - test_value).abs() >= tolerance);
+        }
+    }
+
+    #[test]
+    fn test_momentum_faster_than_gd() {
+        fn derivative_of_square(params: &[f64]) -> Vec<f64> {
+            params.iter().map(|x| 2.0 * x).collect()
+        }
+
+        // Test that momentum converges faster than gradient descent
+        let mut x_momentum: Vec<f64> = vec![5.0, 6.0];
+        let mut x_gd: Vec<f64> = vec![5.0, 6.0];
+        let learning_rate: f64 = 0.01;
+        let beta: f64 = 0.9;
+        let num_iterations: i32 = 50;
+
+        momentum(
+            derivative_of_square,
+            &mut x_momentum,
+            learning_rate,
+            beta,
+            num_iterations,
+        );
+
+        // Gradient descent from your original implementation
+        for _ in 0..num_iterations {
+            let gradient = derivative_of_square(&x_gd);
+            for (x_k, grad) in x_gd.iter_mut().zip(gradient.iter()) {
+                *x_k -= learning_rate * grad;
+            }
+        }
+
+        // Momentum should be closer to zero
+        let momentum_distance: f64 = x_momentum.iter().map(|x| x * x).sum();
+        let gd_distance: f64 = x_gd.iter().map(|x| x * x).sum();
+
+        assert!(momentum_distance < gd_distance);
+    }
+}


### PR DESCRIPTION
76 This is not a bug but rather expected behavior when using an unsupported Python version. Our documentation clearly states that Python 3.8+ is required, and the user was running 3.6 which reached end-of-life in December 2021.